### PR TITLE
Small typo in the documentation: the name of the style is `blobs`, not `blob`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You may use `\fancyqr` just like the normal `\qrcode` (`\fancyqr[<qr-options>]{<
 *fancyqr* is actively developed by *Florian Sihler* (contact me at: <florian.sihler@uni-ulm.de>) under the [GPLv3 License](LICENSE). I am very happy about every contribution (see [CONTRIBUTING.md](CONTRIBUTING.md)). You can find it on CTAN (<https://www.ctan.org/pkg/fancyqr>).
 
 If you do want to hide a center square (e.g., because you want to embed an image), you can use `\FancyQrDoNotPrintSquare{<x>}{<y>}` to hide a rectangle with radius x and y set from the center. If you choose this option, the default `\FancyQrRoundCut` that rounds cut corners can be changed with `\FancyQrHardCut`.
-At the moment, there are six other styles (`flat`, `frame`, `blob`, `glitch`, `swift`, and `dots`) that you can load (locally) by using `\FancyQrLoad{<name>}`. The default style is named `default` and can be 'reset' by `\FancyQrLoad{default}` or `\FancyQrLoadDefault`.
+At the moment, there are six other styles (`flat`, `frame`, `blobs`, `glitch`, `swift`, and `dots`) that you can load (locally) by using `\FancyQrLoad{<name>}`. The default style is named `default` and can be 'reset' by `\FancyQrLoad{default}` or `\FancyQrLoadDefault`.
 
 There are the following extra qr-options (you can set all of them with `\fancyqrset{<keys>}`):
 | Option            | Type    | Default  | Explanation                                                |

--- a/fancyqr-doc.tex
+++ b/fancyqr-doc.tex
@@ -45,7 +45,7 @@
 	You can use the |\fancyqr|-macro just like the normal |\qrcode|.\footnote{\ltx{\\fancyqr[<qr-options>]\{<url>\}}}
 
 	If you do want to hide a center square (e.g, because you want to embed an image) you can use |\FancyQrDoNotPrintSquare{<x>}{<y>}| to hide a rectangle with radius x and y set from the center. If you choose this option, the default |\FancyQrRoundCut| that rounds cut corners can be changed with |\FancyQrHardCut|.
-	At the moment, there are six other styles for the qr-code |flat|, |frame|, |blob|, |glitch|, |swift|, and |dots|, that you can load (locally) by using |\FancyQrLoad{<name>}|. The default style is named |default| and can be 'reset' by |\FancyQrLoad{default}| or |\FancyQrLoadDefault|.
+	At the moment, there are six other styles for the qr-code |flat|, |frame|, |blobs|, |glitch|, |swift|, and |dots|, that you can load (locally) by using |\FancyQrLoad{<name>}|. The default style is named |default| and can be 'reset' by |\FancyQrLoad{default}| or |\FancyQrLoadDefault|.
 
 	All of the extra qr-options (you can set all of them with |\fancyqrset{<keys>}|) are showcased in \autoref{tbl:extra-keys}.
 	The defaults are set like this:


### PR DESCRIPTION
I just added the missing _S_.

Thanks for your work!
(I discovered the typo in the documentation while adding your package to our French-speaking LaTeX FAQ: [Produce QR codes in LaTeX](https://www.latex-fr.net/4_domaines_specialises/commerce/generer_des_qr_codes)).