### PR TITLE
Remove tikz dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You may use `\fancyqr` just like the normal `\qrcode` (`\fancyqr[<qr-options>]{<
 *fancyqr* is actively developed by *Florian Sihler* (contact me at: <florian.sihler@uni-ulm.de>) under the [GPLv3 License](LICENSE). I am very happy about every contribution (see [CONTRIBUTING.md](CONTRIBUTING.md)). You can find it on CTAN (<https://www.ctan.org/pkg/fancyqr>).
 
 If you do want to hide a center square (e.g., because you want to embed an image), you can use `\FancyQrDoNotPrintSquare{<x>}{<y>}` to hide a rectangle with radius x and y set from the center. If you choose this option, the default `\FancyQrRoundCut` that rounds cut corners can be changed with `\FancyQrHardCut`.
-At the moment, there are six other styles (`flat`, `frame`, `blobs`, `glitch`, `swift`, and `dots`) that you can load (locally) by using `\FancyQrLoad{<name>}`. The default style is named `default` and can be 'reset' by `\FancyQrLoad{default}` or `\FancyQrLoadDefault`.
+At the moment, there are six other styles (`flat`, `frame`, `blobs`, `glitch`, and `dots`) that you can load (locally) by using `\FancyQrLoad{<name>}`. The default style is named `default` and can be 'reset' by `\FancyQrLoad{default}` or `\FancyQrLoadDefault`.
 
 There are the following extra qr-options (you can set all of them with `\fancyqrset{<keys>}`):
 | Option            | Type    | Default  | Explanation                                                |

--- a/fancyqr-doc.tex
+++ b/fancyqr-doc.tex
@@ -45,7 +45,7 @@
 	You can use the |\fancyqr|-macro just like the normal |\qrcode|.\footnote{\ltx{\\fancyqr[<qr-options>]\{<url>\}}}
 
 	If you do want to hide a center square (e.g, because you want to embed an image) you can use |\FancyQrDoNotPrintSquare{<x>}{<y>}| to hide a rectangle with radius x and y set from the center. If you choose this option, the default |\FancyQrRoundCut| that rounds cut corners can be changed with |\FancyQrHardCut|.
-	At the moment, there are six other styles for the qr-code |flat|, |frame|, |blobs|, |glitch|, |swift|, and |dots|, that you can load (locally) by using |\FancyQrLoad{<name>}|. The default style is named |default| and can be 'reset' by |\FancyQrLoad{default}| or |\FancyQrLoadDefault|.
+	At the moment, there are six other styles for the qr-code |flat|, |frame|, |blobs|, |glitch|, and |dots|, that you can load (locally) by using |\FancyQrLoad{<name>}|. The default style is named |default| and can be 'reset' by |\FancyQrLoad{default}| or |\FancyQrLoadDefault|.
 
 	All of the extra qr-options (you can set all of them with |\fancyqrset{<keys>}|) are showcased in \autoref{tbl:extra-keys}.
 	The defaults are set like this:

--- a/fancyqr-style-blobs.code
+++ b/fancyqr-style-blobs.code
@@ -1,23 +1,36 @@
-\def\@tikz@fancy@qr@blobb{[rounded corners=.08*\qrm] (0,0) +(0:.3*\qrm+.515*\qrm*rnd) foreach \a in {30,60,...,360} {-- +(\a:.3*\qrm+.515*\qrm*rnd)} -- cycle}%
+% with pict2e and polar coordinate translation
+\def\@fancy@qr@blobb{%
+\@tempcnta=\z@
+\roundjoin
+\roundcap
+\moveto(0,0)
+\loop
+\advance\@tempcnta by 30
+\edef\rad{\fpeval{.2*\qr@modulesize+.115*\qr@modulesize*abs(rand())}}% fixed rand for both
+\lineto(\fpeval{cos(\@tempcnta)*\rad},\fpeval{sin(\@tempcnta)*\rad})
+\ifnum\@tempcnta<360\relax
+\repeat
+\fillpath
+}%
 % .
-\newpattern0000{\@tikz@fancy@qr@blobb}%
+\newpattern0000{\@fancy@qr@blobb}%
 % | | - -
-\newpattern1000{\@tikz@fancy@qr@blobb}%
-\newpattern0001{\@tikz@fancy@qr@blobb}%
-\newpattern0100{\@tikz@fancy@qr@blobb}%
-\newpattern0010{\@tikz@fancy@qr@blobb}%
+\newpattern1000{\@fancy@qr@blobb}%
+\newpattern0001{\@fancy@qr@blobb}%
+\newpattern0100{\@fancy@qr@blobb}%
+\newpattern0010{\@fancy@qr@blobb}%
 % corners
-\newpattern1100{\@tikz@fancy@qr@blobb}%
-\newpattern1010{\@tikz@fancy@qr@blobb}%
-\newpattern0101{\@tikz@fancy@qr@blobb}%
-\newpattern0011{\@tikz@fancy@qr@blobb}%
+\newpattern1100{\@fancy@qr@blobb}%
+\newpattern1010{\@fancy@qr@blobb}%
+\newpattern0101{\@fancy@qr@blobb}%
+\newpattern0011{\@fancy@qr@blobb}%
 % straights | --
-\newpattern1001{\@tikz@fancy@qr@blobb}%
-\newpattern0110{\@tikz@fancy@qr@blobb}%
+\newpattern1001{\@fancy@qr@blobb}%
+\newpattern0110{\@fancy@qr@blobb}%
 % enclosed
-\newpattern1111{\@tikz@fancy@qr@blobb}%
+\newpattern1111{\@fancy@qr@blobb}%
 % t's
-\newpattern0111{\@tikz@fancy@qr@blobb}%
-\newpattern1011{\@tikz@fancy@qr@blobb}%
-\newpattern1101{\@tikz@fancy@qr@blobb}%
-\newpattern1110{\@tikz@fancy@qr@blobb}%
+\newpattern0111{\@fancy@qr@blobb}%
+\newpattern1011{\@fancy@qr@blobb}%
+\newpattern1101{\@fancy@qr@blobb}%
+\newpattern1110{\@fancy@qr@blobb}%

--- a/fancyqr-style-dots.code
+++ b/fancyqr-style-dots.code
@@ -1,22 +1,23 @@
+\def\fancyqr@dots@circle{\put(.5,.5){\circle*{\@ne}}}
 % .
-\newpattern0000{(0,0)circle[radius=.475*\qrm]}%
+\newpattern0000{\fancyqr@dots@circle}%
 % | | - -
-\newpattern1000{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0001{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0100{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0010{(0,0)circle[radius=.475*\qrm]}%
+\newpattern1000{\fancyqr@dots@circle}%
+\newpattern0001{\fancyqr@dots@circle}%
+\newpattern0100{\fancyqr@dots@circle}%
+\newpattern0010{\fancyqr@dots@circle}%
 % corners
-\newpattern1100{(0,0)circle[radius=.475*\qrm]}%
-\newpattern1010{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0101{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0011{(0,0)circle[radius=.475*\qrm]}%
+\newpattern1100{\fancyqr@dots@circle}%
+\newpattern1010{\fancyqr@dots@circle}%
+\newpattern0101{\fancyqr@dots@circle}%
+\newpattern0011{\fancyqr@dots@circle}%
 % straights | --
-\newpattern1001{(0,0)circle[radius=.475*\qrm]}%
-\newpattern0110{(0,0)circle[radius=.475*\qrm]}%
+\newpattern1001{\fancyqr@dots@circle}%
+\newpattern0110{\fancyqr@dots@circle}%
 % enclosed
-\newpattern1111{(0,0)circle[radius=.475*\qrm]}%
+\newpattern1111{\fancyqr@dots@circle}%
 % t's
-\newpattern0111{(0,0)circle[radius=.475*\qrm]}%
-\newpattern1011{(0,0)circle[radius=.475*\qrm]}%
-\newpattern1101{(0,0)circle[radius=.475*\qrm]}%
-\newpattern1110{(0,0)circle[radius=.475*\qrm]}%
+\newpattern0111{\fancyqr@dots@circle}%
+\newpattern1011{\fancyqr@dots@circle}%
+\newpattern1101{\fancyqr@dots@circle}%
+\newpattern1110{\fancyqr@dots@circle}%

--- a/fancyqr-style-flat.code
+++ b/fancyqr-style-flat.code
@@ -1,22 +1,23 @@
+\def\fancyqr@flat@rect{\moveto(0,0)\lineto(0,1)\lineto(1,1)\lineto(1,0)\lineto(0,0)\fillpath}
 % .
-\newpattern0000{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern0000{\fancyqr@flat@rect}%
 % | | - -
-\newpattern1000{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0001{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0100{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0010{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern1000{\fancyqr@flat@rect}%
+\newpattern0001{\fancyqr@flat@rect}%
+\newpattern0100{\fancyqr@flat@rect}%
+\newpattern0010{\fancyqr@flat@rect}%
 % corners
-\newpattern1100{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1010{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0101{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0011{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern1100{\fancyqr@flat@rect}%
+\newpattern1010{\fancyqr@flat@rect}%
+\newpattern0101{\fancyqr@flat@rect}%
+\newpattern0011{\fancyqr@flat@rect}%
 % straights | --
-\newpattern1001{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0110{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern1001{\fancyqr@flat@rect}%
+\newpattern0110{\fancyqr@flat@rect}%
 % enclosed
-\newpattern1111{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern1111{\fancyqr@flat@rect}%
 % t's
-\newpattern0111{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1011{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1101{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1110{(0,0)rectangle(\qrm,\qrm)}%
+\newpattern0111{\fancyqr@flat@rect}%
+\newpattern1011{\fancyqr@flat@rect}%
+\newpattern1101{\fancyqr@flat@rect}%
+\newpattern1110{\fancyqr@flat@rect}%

--- a/fancyqr-style-frame.code
+++ b/fancyqr-style-frame.code
@@ -1,25 +1,2 @@
-\tikzset{qrrd/.style={draw,line width=1.25pt}}
-\def\qrframesuffix{; \path[fill,qrrc,fill opacity=.995] (-.1pt,-.1pt) rectangle (\qrm+.1pt,\qrm+.1pt)}
-\def\qrfillring{circle[radius=.625pt]}
-% .
-\newpattern0000{[qrrc](0,0)rectangle(\qrm,\qrm); \path[fill,fill opacity=.965] (\qrm/2,\qrm/2) circle[radius=\qrm/3]}
-% | | - -
-\newpattern1000{(0,\qrm)[qrrc] -- (0,0) -- (\qrm,0) -- (\qrm,\qrm)\qrframesuffix}
-\newpattern0001{(0,0)[qrrc] -- (0,\qrm) -- (\qrm,\qrm) -- (\qrm,0)\qrframesuffix}
-\newpattern0100{(0,0)[qrrc] -- (\qrm,0) -- (\qrm,\qrm) -- (0,\qrm)\qrframesuffix}
-\newpattern0010{(\qrm,0)[qrrc] -- (0,0) -- (0,\qrm) -- (\qrm,\qrm)\qrframesuffix}
-% corners; the good injections to cover loose lines
-\newpattern1100{(\qrm,\qrm)[qrrc] -- (\qrm,0) -- (0,0); \path[fill] (0,\qrm) \qrfillring\qrframesuffix}% top left
-\newpattern1010{(0,\qrm)[qrrc] -- (0,0) -- (\qrm,0); \path[fill] (\qrm,\qrm) \qrfillring\qrframesuffix}% top right
-\newpattern0101{(0,\qrm)[qrrc] -- (\qrm,\qrm) -- (\qrm,0); \path[fill] (0,0) \qrfillring\qrframesuffix}% bottom left
-\newpattern0011{(\qrm,\qrm)[qrrc] -- (0,\qrm) -- (0,0) (\qrm,0); \path[fill] (\qrm,0) \qrfillring\qrframesuffix}% bottom right
-% straights | --
-\newpattern1001{(0,0)--(0,\qrm) (\qrm,0)--(\qrm,\qrm)\qrframesuffix}
-\newpattern0110{(0,0)--(\qrm,0) (0,\qrm)--(\qrm,\qrm)\qrframesuffix}
-% enclosed
-\newpattern1111{; \path[fill] (0,0) \qrfillring; \path[fill] (0,\qrm) \qrfillring; \path[fill] (\qrm,0) \qrfillring; \path[fill] (\qrm,\qrm) \qrfillring\qrframesuffix}
-% t's
-\newpattern0111{(0,\qrm)--(\qrm,\qrm); \path[fill] (0,0) \qrfillring; \path[fill] (\qrm,0) \qrfillring\qrframesuffix} % -,-
-\newpattern1011{(0,\qrm)--(0,0); \path[fill] (\qrm,0) \qrfillring; \path[fill] (\qrm,\qrm)\qrfillring\qrframesuffix}
-\newpattern1101{(\qrm,\qrm)--(\qrm,0); \path[fill] (0,0) \qrfillring; \path[fill] (0,\qrm)\qrfillring\qrframesuffix}
-\newpattern1110{(0,0)--(\qrm,0); \path[fill] (0,\qrm) \qrfillring; \path[fill] (\qrm,\qrm) \qrfillring\qrframesuffix} % -'-
+\def\fancyqr@rounded@rect@close{\linethickness{.1\qr@modulesize}\closepath\strokepath}%
+\FancyQrLoadDefault

--- a/fancyqr-style-glitch.code
+++ b/fancyqr-style-glitch.code
@@ -1,23 +1,35 @@
-\def\@tikz@fancy@qr@blobb{[qrrc] (0,0) +(0:.35*\qrm+.25*\qrm*rnd) foreach \a in {20,40,...,359} {-- +(\a:.35*\qrm+.2*\qrm*rnd)} -- cycle}%
+\def\@fancy@qr@blobb{%
+\@tempcnta=\z@
+\roundjoin
+\roundcap
+\moveto(0,0)
+\loop
+\advance\@tempcnta by 40
+\def\rad{\fpeval{.2*\qr@modulesize+.115*\qr@modulesize*rand()}}% allow to 'glitch'
+\lineto(\fpeval{cos(\@tempcnta)*\rad},\fpeval{sin(\@tempcnta)*\rad})
+\ifnum\@tempcnta<360\relax
+\repeat
+\fillpath
+}%
 % .
-\newpattern0000{\@tikz@fancy@qr@blobb}%
+\newpattern0000{\@fancy@qr@blobb}%
 % | | - -
-\newpattern1000{\@tikz@fancy@qr@blobb}%
-\newpattern0001{\@tikz@fancy@qr@blobb}%
-\newpattern0100{\@tikz@fancy@qr@blobb}%
-\newpattern0010{\@tikz@fancy@qr@blobb}%
+\newpattern1000{\@fancy@qr@blobb}%
+\newpattern0001{\@fancy@qr@blobb}%
+\newpattern0100{\@fancy@qr@blobb}%
+\newpattern0010{\@fancy@qr@blobb}%
 % corners
-\newpattern1100{\@tikz@fancy@qr@blobb}%
-\newpattern1010{\@tikz@fancy@qr@blobb}%
-\newpattern0101{\@tikz@fancy@qr@blobb}%
-\newpattern0011{\@tikz@fancy@qr@blobb}%
+\newpattern1100{\@fancy@qr@blobb}%
+\newpattern1010{\@fancy@qr@blobb}%
+\newpattern0101{\@fancy@qr@blobb}%
+\newpattern0011{\@fancy@qr@blobb}%
 % straights | --
-\newpattern1001{\@tikz@fancy@qr@blobb}%
-\newpattern0110{\@tikz@fancy@qr@blobb}%
+\newpattern1001{\@fancy@qr@blobb}%
+\newpattern0110{\@fancy@qr@blobb}%
 % enclosed
-\newpattern1111{\@tikz@fancy@qr@blobb}%
+\newpattern1111{\@fancy@qr@blobb}%
 % t's
-\newpattern0111{\@tikz@fancy@qr@blobb}%
-\newpattern1011{\@tikz@fancy@qr@blobb}%
-\newpattern1101{\@tikz@fancy@qr@blobb}%
-\newpattern1110{\@tikz@fancy@qr@blobb}%
+\newpattern0111{\@fancy@qr@blobb}%
+\newpattern1011{\@fancy@qr@blobb}%
+\newpattern1101{\@fancy@qr@blobb}%
+\newpattern1110{\@fancy@qr@blobb}%

--- a/fancyqr-style-swift.code
+++ b/fancyqr-style-swift.code
@@ -1,24 +1,2 @@
-\def\fancy@qrbound{;\pgfresetboundingbox\path(0,0)rectangle(\qrm,\qrm)}%
-% note: the expansion with two seems to be problematic, therefore i use cordinate
-% .
-\newpattern0000{(.5*\qrm,1.1*\qrm)coordinate(@)(1.1*\qrm,.5*\qrm)coordinate(@b)(.5*\qrm,-.1*\qrm)coordinate(@c)(-.1*\qrm,.5*\qrm)coordinate(@d)to[bend right=15](@)to[bend right=15](@b)to[bend right=15](@c)to[bend right=15](@d)\fancy@qrbound}%
-% | | - -
-\newpattern1000{(.5*\qrm,-.1*\qrm)coordinate(@)(0,.2*\qrm)coordinate(@b)|-(\qrm,\qrm)--(\qrm,.2*\qrm)to[out=181,in=65](@)to[out=115,in=1](@b)}%
-\newpattern0001{(.5*\qrm,1.1*\qrm)coordinate(@)(0,.8*\qrm)coordinate(@b)|-(\qrm,0)--(\qrm,.8*\qrm)to[out=179,in=290](@)to[out=250,in=1](@b)}%
-\newpattern0100{(1.1*\qrm,.5*\qrm)coordinate(@)(.8*\qrm,\qrm)coordinate(@b)-|(0,0)--(.8*\qrm,0)to[out=89,in=205](@)to[out=155,in=271](@b)}%
-\newpattern0010{(-.1*\qrm,.5*\qrm)coordinate(@)(.2*\qrm,\qrm)coordinate(@b)-|(\qrm,0)--(.2*\qrm,0)to[out=91,in=335](@)to[out=25,in=269](@b)}%
-% corners
-\newpattern1100{(1.1*\qrm,-.1*\qrm)coordinate(@)(\qrm,\qrm)to[out=271,in=105](@)to[out=155,in=-1](0,0)--(0,\qrm)--(\qrm,\qrm)\fancy@qrbound}%
-\newpattern1010{(-.1*\qrm,-.1*\qrm)coordinate(@)(\qrm,0)coordinate(@b)(0,\qrm)to[out=269,in=75](@)to[out=25,in=181](@b)--(\qrm,\qrm)--(0,\qrm)\fancy@qrbound}%
-\newpattern0101{(\qrm+.1*\qrm,\qrm+.1*\qrm)coordinate(@)(0,\qrm)coordinate(@b)(@b) |- (\qrm,0) to[out=89,in=255](@)to[out=205,in=1](@b)\fancy@qrbound}%
-\newpattern0011{(-.1*\qrm,\qrm+.1*\qrm)coordinate(@)(0,0)coordinate(@b)(@b) -| (\qrm,\qrm) to[out=179,in=335](@)to[out=285,in=91](@b)\fancy@qrbound}%
-% straights | --
-\newpattern1001{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern0110{(0,0)rectangle(\qrm,\qrm)}%
-% enclosed
-\newpattern1111{(0,0)rectangle(\qrm,\qrm)}%
-% t's
-\newpattern0111{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1011{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1101{(0,0)rectangle(\qrm,\qrm)}%
-\newpattern1110{(0,0)rectangle(\qrm,\qrm)}%
+\PackageWarning{fancyqr}{Currently, swift is not supported :/}
+\FancyQrLoadDefault

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -191,8 +191,9 @@
    \endminipage
    \if@fancyqr@image@\nobreak
    \llap{\parbox\qr@minipagewidth{\centering\usebox\fancyqr@imgbox}%
-      % if the width is even, offset by half a module width, done by centering
-      \ifodd\fancy@qr@donotprint@center@x\else\kern.5\qr@modulesize\fi
+      % if half the width is odd, offset by half a module width, done by centering
+      \edef\@halfcheck{\fpeval{round(\fancy@qr@donotprint@center@x/2)}}%
+      \ifodd\@halfcheck \kern.5\qr@modulesize\fi
    }\fi
 }%
 

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -15,8 +15,8 @@
    % we do rotate the x and y points before color drawing by
    % Mod(\fancyqr@gradient@angle,360) with the shifted origin
    % Old: #3/2 #4/2
-   ((\the\j-\@max@x/2)*cos(\angle) - (\the\i-\@max@y/2)*sin(\angle) + \@max@x/2)/\@max@x * 50% rel x [0,1]
-   + ((\the\j-\@max@x/2)*sin(\angle) + (\the\i-\@max@y/2)*cos(\angle) + \@max@y/2)/\@max@y * 50% rel y [0,1]
+   ((\the\j-\@half@max@x)*cos(\angle) - (\the\i-\@half@max@y)*sin(\angle) + \@half@max@x)/\@max@x * 50% rel x [0,1]
+   + ((\the\j-\@half@max@x)*sin(\angle) + (\the\i-\@half@max@y)*cos(\angle) + \@half@max@y)/\@max@y * 50% rel y [0,1]
    }}\@declaredcolor{qr@fancy@gradient@br!\gradient!qr@fancy@gradient@tl}{#1}}
 \def\@@fancyqr@color@default#1{\@declaredcolor{qr@fancy@gradient@tl}{#1}}
 \def\@@fancyqr@color@random#1{\pgfmathrandomitem{\@fancyqr@random@c@l@r}{@@fancyqr@@randomcol}\@declaredcolor{\@fancyqr@random@c@l@r}{#1}}
@@ -144,6 +144,7 @@
 
 \def\fancy@qr@printmatrix#1{%
    \def\qr@white{0}\def\qr@black{1}%
+   \protected@edef\fancyqr@currprint{#1}%
    \let\qr@black@fixed\qr@black
    \let\qr@white@fixed\qr@white
    \let\qr@black@format\qr@black
@@ -164,26 +165,26 @@
       \baselineskip=\qr@modulesize
       \lineskiplimit=\z@ \lineskip=\z@ \parskip=\z@
       \ifqr@tight\else\rule\z@{4\qr@modulesize}\par\fi% %Blank space at top.
-      \edef\@max@x{\qr@numberofrowsinmatrix{#1}}%
-      \edef\@max@y{\qr@numberofcolsinmatrix{#1}}%
-      \edef\@do@x@min{\the\numexpr\@max@x/2-\fancy@qr@donotprint@center@x-\@ne}%
-      \edef\@do@x@max{\the\numexpr\@max@x/2+\fancy@qr@donotprint@center@x+\@ne}%
-      \edef\@do@y@min{\the\numexpr\@max@y/2-\fancy@qr@donotprint@center@y-\@ne}%
-      \edef\@do@y@max{\the\numexpr\@max@y/2+\fancy@qr@donotprint@center@y+\@ne}%
+      \edef\@max@x{\qr@numberofrowsinmatrix\fancyqr@currprint}\edef\@half@max@x{\the\numexpr\@max@x/2}%
+      \edef\@max@y{\qr@numberofcolsinmatrix\fancyqr@currprint}\edef\@half@max@y{\the\numexpr\@max@y/2}%
+      \edef\@do@x@min{\the\numexpr\@half@max@x-\fancy@qr@donotprint@center@x-\@ne}%
+      \edef\@do@x@max{\the\numexpr\@half@max@x+\fancy@qr@donotprint@center@x+\@ne}%
+      \edef\@do@y@min{\the\numexpr\@half@max@y-\fancy@qr@donotprint@center@y-\@ne}%
+      \edef\@do@y@max{\the\numexpr\@half@max@y+\fancy@qr@donotprint@center@y+\@ne}%
       \qr@for \i=\@ne to \@max@y by \@ne{%
-      \ifqr@tight\else \rule{4\qr@modulesize}\z@\fi% %Blank space at left.
+      \ifqr@tight\else\rule{4\qr@modulesize}\z@\fi% %Blank space at left.
       \qr@for \j=\@ne to \@max@x by \@ne{%
          \qr@fancy@updateif\i\j
          \iffancy@qr@do@print@
-         \edef\@mid{\qr@matrixentry{#1}{\the\i}{\the\j}}%
+         \edef\@mid{\qr@matrixentry\fancyqr@currprint{\the\i}{\the\j}}%
          \ifnum\@mid=\qr@white
             \rule\qr@modulesize\z@
          \else% if not white, get its pattern
-            \iffancy@qr@roundcut@\qr@fancy@clear@surround{#1}{\the\i}{\the\j}\fi
-            \edef\@up{\qr@matrixentry{#1}{\the\numexpr\the\i-1}{\the\j}}%
-            \edef\@left{\qr@matrixentry{#1}{\the\i}{\the\numexpr\the\j-1}}%
-            \edef\@right{\qr@matrixentry{#1}{\the\i}{\the\numexpr\the\j+1}}%
-            \edef\@down{\qr@matrixentry{#1}{\the\numexpr\the\i+1}{\the\j}}%
+            \iffancy@qr@roundcut@\qr@fancy@clear@surround\fancyqr@currprint{\the\i}{\the\j}\fi
+            \edef\@up{\qr@matrixentry\fancyqr@currprint{\the\numexpr\the\i-1}{\the\j}}%
+            \edef\@left{\qr@matrixentry\fancyqr@currprint{\the\i}{\the\numexpr\the\j-1}}%
+            \edef\@right{\qr@matrixentry\fancyqr@currprint{\the\i}{\the\numexpr\the\j+1}}%
+            \edef\@down{\qr@matrixentry\fancyqr@currprint{\the\numexpr\the\i+1}{\the\j}}%
             \FancyQrColor{\GetPattern}%
          \fi\else \rule\qr@modulesize\z@\fi
       }\par}%

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -152,27 +152,27 @@
   \qr@modulesize=\qr@desiredheight
   \divide\qr@modulesize by \qr@size\relax
   \unitlength=\dimexpr\qr@modulesize+\fancyqr@edge@compensate\relax % initialize unitlength once
-  \qr@minipagewidth=\qr@modulesize
   \if@fancyqr@image@% image is in \fancyqr@imgbox
    \edef\@x{\fpeval{ceil((.5\wd\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@x}}%
    \edef\@y{\fpeval{ceil((.5\ht\fancyqr@imgbox+.5\dp\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@y}}%
    \FancyQrDoNotPrintSquare\@x\@y
   \fi
-  \multiply\qr@minipagewidth by \qr@size\relax
-  \ifqr@tight \else \advance\qr@minipagewidth by 8\qr@modulesize \fi
-   \minipage\qr@minipagewidth
+  \qr@minipagewidth=\qr@desiredheight
+  \ifqr@tight \advance\qr@minipagewidth by -\qr@modulesize \else \advance\qr@minipagewidth by 7\qr@modulesize \fi
+  \minipage\qr@minipagewidth%
+      \hfuzz=\qr@modulesize
       \baselineskip=\qr@modulesize
       \lineskiplimit=\z@ \lineskip=\z@ \parskip=\z@
       \ifqr@tight\else\rule\z@{4\qr@modulesize}\par\fi% %Blank space at top.
       \edef\@max@x{\qr@numberofrowsinmatrix{#1}}%
       \edef\@max@y{\qr@numberofcolsinmatrix{#1}}%
-      \edef\@do@x@min{\the\numexpr\@max@x/2-\fancy@qr@donotprint@center@x-1}%
-      \edef\@do@x@max{\the\numexpr\@max@x/2+\fancy@qr@donotprint@center@x+1}%
-      \edef\@do@y@min{\the\numexpr\@max@y/2-\fancy@qr@donotprint@center@y-1}%
-      \edef\@do@y@max{\the\numexpr\@max@y/2+\fancy@qr@donotprint@center@y+1}%
-      \qr@for \i=1 to \@max@y by 1{%
-      \ifqr@tight\else\rule{4\qr@modulesize}\z@\fi% %Blank space at left.
-      \qr@for \j=1 to \@max@x by 1{%
+      \edef\@do@x@min{\the\numexpr\@max@x/2-\fancy@qr@donotprint@center@x-\@ne}%
+      \edef\@do@x@max{\the\numexpr\@max@x/2+\fancy@qr@donotprint@center@x+\@ne}%
+      \edef\@do@y@min{\the\numexpr\@max@y/2-\fancy@qr@donotprint@center@y-\@ne}%
+      \edef\@do@y@max{\the\numexpr\@max@y/2+\fancy@qr@donotprint@center@y+\@ne}%
+      \qr@for \i=\@ne to \@max@y by \@ne{%
+      \ifqr@tight\else \rule{4\qr@modulesize}\z@\fi% %Blank space at left.
+      \qr@for \j=\@ne to \@max@x by \@ne{%
          \qr@fancy@updateif\i\j
          \iffancy@qr@do@print@
          \edef\@mid{\qr@matrixentry{#1}{\the\i}{\the\j}}%

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -3,22 +3,27 @@
 % https://opensource.org/licenses/gpl-3.0.html
 \def\filename{fancyqr}
 \ProvidesPackage{\filename}[2022/08/19 version v1.1 Fancy QR-Codes]
-\RequirePackage{tikz, qrcode}
+\RequirePackage{pict2e, xfp, qrcode}
 
 % element
 % x: {\the\j}; y: {\the\i} | \@max@x \@max@y
-\def\@@fancyqr@color@gradient#1{\pgfmathsetmacro\angle{Mod(\fancyqr@gradient@angle+225,360)}% rotate to align 0 to the right
-\pgfmathsetmacro\gradient{%
+\def\@@fancyqr@color@gradient#1{\edef\angle{\fpeval{%
+   % approximate mod
+   \fancyqr@gradient@angle+225 - floor((\fancyqr@gradient@angle+225)/360)*360
+}}% rotate to align 0 to the right
+\edef\gradient{\fpeval{%
    % we do rotate the x and y points before color drawing by
    % Mod(\fancyqr@gradient@angle,360) with the shifted origin
    % Old: #3/2 #4/2
    ((\the\j-\@max@x/2)*cos(\angle) - (\the\i-\@max@y/2)*sin(\angle) + \@max@x/2)/\@max@x * 50% rel x [0,1]
    + ((\the\j-\@max@x/2)*sin(\angle) + (\the\i-\@max@y/2)*cos(\angle) + \@max@y/2)/\@max@y * 50% rel y [0,1]
-   }\@declaredcolor{qr@fancy@gradient@br!\gradient!qr@fancy@gradient@tl}{#1}}
+   }}\@declaredcolor{qr@fancy@gradient@br!\gradient!qr@fancy@gradient@tl}{#1}}
 \def\@@fancyqr@color@default#1{\@declaredcolor{qr@fancy@gradient@tl}{#1}}
 \def\@@fancyqr@color@random#1{\pgfmathrandomitem{\@fancyqr@random@c@l@r}{@@fancyqr@@randomcol}\@declaredcolor{\@fancyqr@random@c@l@r}{#1}}
 \let\FancyQrColor\@@fancyqr@color@default
 
+\def\fancyqr@rounding@factor{.5}
+\edef\fancyqr@rounding@other{\fpeval{1-\fancyqr@rounding@factor}}
 
 % O 1 O
 % 2 X 3
@@ -29,46 +34,71 @@
    \csname qcc\@up\@left\@right\@down\endcsname
 \else\rule\qr@modulesize\z@\fi}
 
-\tikzset{qrrc/.style={rounded corners=.5\qr@modulesize},qrrd/.style={fill}}
-
 % backwards compatibility
 \def\fancyqr@clap#1{\hb@xt@\z@{\hss#1\hss}}
+\newdimen\fancyqr@edge@compensate
+\fancyqr@edge@compensate=.15\p@
 
 % is larger to be compensated by overlaps
-\def\qrm{\dimexpr\qr@modulesize+.15\p@\relax}
+\def\qrm{\dimexpr\qr@modulesize+\fancyqr@edge@compensate\relax}
 \long\def\qr@newpattern#1#2#3#4#5{%
-\expandafter\def\csname qcc#1#2#3#4\endcsname{%
-   \parbox[b][\qr@modulesize]\qr@modulesize{\kern-.075\p@\smash{\fancyqr@clap{\tikz[x=\qrm,y=\qrm,inner sep=\z@,outer sep=\z@]{\path[qrrd]#5;}}}}%
+\expandafter\def\csname qcc#1#2#3#4\endcsname{\parbox[b][\qr@modulesize]\qr@modulesize{\kern-\fancyqr@edge@compensate\relax\smash{\fancyqr@clap{\picture(\@ne,\@ne)#5\endpicture}}}%
 }}
+
+% [#3][#2]
+% [#4][#1]
+\def\fancyqr@rounded@rect#1#2#3#4{%
+   \ifnum#4=\@ne\relax \moveto(\fancyqr@rounding@factor,\z@)\else\moveto(\z@,\z@)\fi
+   \ifnum#1=\@ne
+      \lineto(\fancyqr@rounding@other,\z@)%
+      \circlearc\fancyqr@rounding@other\fancyqr@rounding@factor\fancyqr@rounding@factor{270}{360}
+   \else\lineto(\@ne,\z@)\fi
+   \ifnum#2=\@ne
+      \lineto(\@ne,\fancyqr@rounding@other)%
+      \circlearc\fancyqr@rounding@other\fancyqr@rounding@other\fancyqr@rounding@factor{0}{90}
+   \else\lineto(\@ne,\@ne)\fi
+   \ifnum#3=\@ne
+      \lineto(\fancyqr@rounding@factor,\@ne)%
+      \circlearc\fancyqr@rounding@factor\fancyqr@rounding@other\fancyqr@rounding@factor{90}{180}
+   \else\lineto(\z@,\@ne)\fi
+   \ifnum#4=\@ne
+      \lineto(\z@,\fancyqr@rounding@factor)%
+      \circlearc\fancyqr@rounding@factor\fancyqr@rounding@factor\fancyqr@rounding@factor{180}{270}
+   \else\lineto(\z@,\z@)\fi
+   \fancyqr@rounded@rect@close
+}
+\def\fancyqr@rounded@rect@close{\fillpath}
 
 \def\FancyQrLoadDefault{%
 % .
-\qr@newpattern0000{[qrrc](0,0)rectangle(\qrm,\qrm)}%
+\qr@newpattern0000{\fancyqr@rounded@rect1111}%
 % | | - -
-\qr@newpattern1000{(0,\qrm)[qrrc]--(0,0)--(\qrm,0)[sharp corners]--(\qrm,\qrm)--cycle}%
-\qr@newpattern0001{(0,0)[qrrc]--(0,\qrm)--(\qrm,\qrm)[sharp corners]--(\qrm,0)--cycle}%
-\qr@newpattern0100{(0,0)[qrrc]--(\qrm,0)--(\qrm,\qrm)[sharp corners]--(0,\qrm)--cycle}%
-\qr@newpattern0010{(\qrm,0)[qrrc]--(0,0)--(0,\qrm)[sharp corners]--(\qrm,\qrm)--cycle}%
+\qr@newpattern1000{\fancyqr@rounded@rect1001}%
+\qr@newpattern0001{\fancyqr@rounded@rect0110}%
+\qr@newpattern0100{\fancyqr@rounded@rect1100}%
+\qr@newpattern0010{\fancyqr@rounded@rect0011}%
 % corners
-\qr@newpattern1100{(\qrm,\qrm)[qrrc]--(\qrm,0)[sharp corners]--(0,0)--(0,\qrm)--cycle}% top left
-\qr@newpattern1010{(0,\qrm)[qrrc]--(0,0)[sharp corners]--(\qrm,0)--(\qrm,\qrm)--cycle}% top right
-\qr@newpattern0101{(0,\qrm)[qrrc]--(\qrm,\qrm)[sharp corners]--(\qrm,0)--(0,0)--cycle}% bottom left
-\qr@newpattern0011{(0,0)[qrrc]--(0,\qrm)[sharp corners]--(\qrm,\qrm)--(\qrm,0)--cycle}% bottom right
+\qr@newpattern1100{\fancyqr@rounded@rect1000}% bottom right
+\qr@newpattern1010{\fancyqr@rounded@rect0001}% bottom left
+\qr@newpattern0101{\fancyqr@rounded@rect0100}% top right
+\qr@newpattern0011{\fancyqr@rounded@rect0010}% top left
 % straights | --
-\qr@newpattern1001{(0,0)rectangle(\qrm,\qrm)}%
-\qr@newpattern0110{(0,0)rectangle(\qrm,\qrm)}%
+\qr@newpattern1001{\fancyqr@rounded@rect0000}%
+\qr@newpattern0110{\fancyqr@rounded@rect0000}%
 % enclosed
-\qr@newpattern1111{(0,0)rectangle(\qrm,\qrm)}%
+\qr@newpattern1111{\fancyqr@rounded@rect0000}%
 % t's
-\qr@newpattern0111{(0,0)rectangle(\qrm,\qrm)}%
-\qr@newpattern1011{(0,0)rectangle(\qrm,\qrm)}%
-\qr@newpattern1101{(0,0)rectangle(\qrm,\qrm)}%
-\qr@newpattern1110{(0,0)rectangle(\qrm,\qrm)}%
+\qr@newpattern0111{\fancyqr@rounded@rect0000}%
+\qr@newpattern1011{\fancyqr@rounded@rect0000}%
+\qr@newpattern1101{\fancyqr@rounded@rect0000}%
+\qr@newpattern1110{\fancyqr@rounded@rect0000}%
 }
 \FancyQrLoadDefault % allows to reset the style after other loads
 \def\@fancy@qr@default@name{default}
 
-\def\FancyQrLoad#1{\let\@tmp\newpattern\let\newpattern\qr@newpattern\@bsphack\def\@@tmp{#1}\ifx\@@tmp\@fancy@qr@default@name\FancyQrLoadDefault\else
+\def\FancyQrLoad#1{%
+\def\fancyqr@rounded@rect@close{\fillpath}%
+\let\@tmp\newpattern\let\newpattern\qr@newpattern\@bsphack\def\@@tmp{#1}\ifx\@@tmp\@fancy@qr@default@name\FancyQrLoadDefault\else
 \expandafter\edef\csname pingu@lib@#1@atcode\endcsname{\the\catcode`\@}%
 \catcode`\@=11\relax
 \input{fancyqr-style-#1.code}
@@ -121,10 +151,11 @@
   %Set module size
   \qr@modulesize=\qr@desiredheight
   \divide\qr@modulesize by \qr@size\relax
+  \unitlength=\dimexpr\qr@modulesize+\fancyqr@edge@compensate\relax % initialize unitlength once
   \qr@minipagewidth=\qr@modulesize
   \if@fancyqr@image@% image is in \fancyqr@imgbox
-   \pgfmathsetmacro\@x{int(ceil((.5\wd\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@x)}%
-   \pgfmathsetmacro\@y{int(ceil((.5\ht\fancyqr@imgbox+.5\dp\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@y)}%
+   \edef\@x{\fpeval{ceil((.5\wd\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@x}}%
+   \edef\@y{\fpeval{ceil((.5\ht\fancyqr@imgbox+.5\dp\fancyqr@imgbox)/\qr@modulesize)+\fancyqr@img@padding@y}}%
    \FancyQrDoNotPrintSquare\@x\@y
   \fi
   \multiply\qr@minipagewidth by \qr@size\relax
@@ -159,7 +190,10 @@
       \ifqr@tight\else\rule\z@{4\qr@modulesize}\par\fi
    \endminipage
    \if@fancyqr@image@\nobreak
-   \llap{\parbox\qr@minipagewidth{\centering\usebox\fancyqr@imgbox}}\fi
+   \llap{\parbox\qr@minipagewidth{\centering\usebox\fancyqr@imgbox}%
+      % if the width is even, offset by half a module width, done by centering
+      \ifodd\fancy@qr@donotprint@center@x\else\kern.5\qr@modulesize\fi
+   }\fi
 }%
 
 \def\fancy@qr@setup#1{%
@@ -240,6 +274,8 @@
 \ifqr@starinvoked\qr@hyperlinkfalse\fi
 \setkeys{qr,fancyqr}{#1}%
 \if@fancyqr@randomcolor@%
+\ifcsname pgfmathdeclarerandomlist\endcsname\else
+\PackageError{fancyqr}{Random colors requested but pgfmath not loaded}{Please load pgfmath if you want this}\fi
 \pgfmathdeclarerandomlist{@@fancyqr@@randomcol}{\@fancyqr@random@colors}\let\FancyQrColor\@@fancyqr@color@random\else\if@fancyqr@gradient\let\FancyQrColor\@@fancyqr@color@gradient\fi\fi
 \bgroup\qr@verbatimcatcodes\qr@setescapedspecials\qrcode@in}
 \endinput

--- a/qr-example.tex
+++ b/qr-example.tex
@@ -16,7 +16,7 @@
 \usepackage[active,tightpage]{preview} % for presentation
 \setlength\PreviewBorder{15pt}
 
-\fancyqrset{size=3.25cm,level=H}
+\fancyqrset{size=3.25cm,level=H, padding}
 
 \errorcontextlines=9999
 
@@ -24,8 +24,8 @@
 \preview
 % \FancyQrDoNotPrintSquare{8}{9}
 % \FancyQrHardCut
-\mbox{% \FancyQrLoad{blobs}
-\fbox{\fancyqr[image=\scalebox{2.9}{\faGithub},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}}
+\mbox{\FancyQrLoad{blobs}
+\fancyqr[image=\scalebox{2.9}{\faGithub},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}
 \FancyQrLoad{default}
 \fancyqr{https://github.com/EagleoutIce/fancyqr}
 \FancyQrLoad{dots}\fancyqr[image={\textsf{\textbf{\textcolor{gray}{fancy}qr}}}, image padding=1, random color={@Red}{@Pink}{@Purple}{@DeepPurple}{@Indigo}{@Blue}{@LightBlue}{@Cyan}{@Teal}{@Green}{@LightGreen}{@Lime}{@Yellow}{@Amber}{@Orange}{@DeepOrange}{@Brown}]{https://github.com/EagleoutIce/fancyqr}

--- a/qr-example.tex
+++ b/qr-example.tex
@@ -5,21 +5,30 @@
 
 \usepackage{fontawesome}
 \usepackage{fancyqr}
-\usepackage[prefix=@]{xcolor-material}% for showcase of random colors
+
+% for showcase of random colors
+\usepackage{pgfmath}
+\usepackage[prefix=@]{xcolor-material}
+
+% to showcase scalebox
+\usepackage{graphicx}
 
 \usepackage[active,tightpage]{preview} % for presentation
 \setlength\PreviewBorder{15pt}
 
-\fancyqrset{size=3.25cm,level=H,padding}
+\fancyqrset{size=3.25cm,level=H}
+
+\errorcontextlines=9999
 
 \begin{document}
 \preview
 % \FancyQrDoNotPrintSquare{8}{9}
 % \FancyQrHardCut
-\mbox{\FancyQrLoad{blobs}
-\fancyqr[image=\scalebox{2.9}{\faGithub\kern1pt},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}
+\mbox{% \FancyQrLoad{blobs}
+\fbox{\fancyqr[image=\scalebox{2.9}{\faGithub},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}}
 \FancyQrLoad{default}
 \fancyqr{https://github.com/EagleoutIce/fancyqr}
-\FancyQrLoad{dots}\fancyqr[image={\kern-1pt\tikz\node[align=center,draw]{\huge Ha\\Huhu};\kern1pt},random color={@Red}{@Pink}{@Purple}{@DeepPurple}{@Indigo}{@Blue}{@LightBlue}{@Cyan}{@Teal}{@Green}{@LightGreen}{@Lime}{@Yellow}{@Amber}{@Orange}{@DeepOrange}{@Brown}]{https://github.com/EagleoutIce/fancyqr}}%
+\FancyQrLoad{dots}\fancyqr[image={\textsf{\textbf{\textcolor{gray}{fancy}qr}}}, image padding=1, random color={@Red}{@Pink}{@Purple}{@DeepPurple}{@Indigo}{@Blue}{@LightBlue}{@Cyan}{@Teal}{@Green}{@LightGreen}{@Lime}{@Yellow}{@Amber}{@Orange}{@DeepOrange}{@Brown}]{https://github.com/EagleoutIce/fancyqr}
+}%
 \endpreview
 \end{document}

--- a/qr-example.tex
+++ b/qr-example.tex
@@ -16,9 +16,7 @@
 \usepackage[active,tightpage]{preview} % for presentation
 \setlength\PreviewBorder{15pt}
 
-\fancyqrset{size=3.25cm,level=H, padding}
-
-\errorcontextlines=9999
+\fancyqrset{size=3.25cm,level=H,padding}
 
 \begin{document}
 \preview

--- a/qr-example.tex
+++ b/qr-example.tex
@@ -24,11 +24,12 @@
 \preview
 % \FancyQrDoNotPrintSquare{8}{9}
 % \FancyQrHardCut
-\mbox{\FancyQrLoad{blobs}
-\fancyqr[image=\scalebox{2.9}{\faGithub},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}
-\FancyQrLoad{default}
-\fancyqr{https://github.com/EagleoutIce/fancyqr}
-\FancyQrLoad{dots}\fancyqr[image={\textsf{\textbf{\textcolor{gray}{fancy}qr}}}, image padding=1, random color={@Red}{@Pink}{@Purple}{@DeepPurple}{@Indigo}{@Blue}{@LightBlue}{@Cyan}{@Teal}{@Green}{@LightGreen}{@Lime}{@Yellow}{@Amber}{@Orange}{@DeepOrange}{@Brown}]{https://github.com/EagleoutIce/fancyqr}
+\mbox{\FancyQrLoad{blobs}%
+\fancyqr[image=\scalebox{2.9}{\faGithub},image padding=1,color=black!90!gray]{https://github.com/EagleoutIce/fancyqr}%
+\FancyQrLoad{default}%
+\fancyqr{https://github.com/EagleoutIce/fancyqr}%
+\FancyQrLoad{dots}%
+\fancyqr[image={\textsf{\textbf{\textcolor{gray}{fancy}qr}}}, random color={@Red}{@Pink}{@Purple}{@DeepPurple}{@Indigo}{@Blue}{@Cyan}{@Teal}{@Green}{@Amber}{@Orange}{@DeepOrange}{@Brown}]{https://github.com/EagleoutIce/fancyqr}%
 }%
 \endpreview
 \end{document}


### PR DESCRIPTION
This recreates the old tikz styles using `pict2e` (and `xfp`, although this package is now integrated into the latex kernel: https://ctan.org/pkg/xfp). This should allow nesting qrcode in tikzpicture without having to think about boxes etc. 

Drops: `swift` style, i did not like it anyways.

Note: the `random color` feature still requires `pgfmath`.

Speed _should_ be improved. 