### PR TITLE
New `compensate` option, no overlap with `classic`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ There are the following extra qr-options (you can set all of them with `\fancyqr
 | ----------------- | ----------- | :------: | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `classic`         | boolean     |  `false` | Use the classic qr-code style (black with flat rectangles, this loads the `flat` style).                                                    |
 | `color`           | color       |          | Disables the `gradient` and sets the qr color accordingly.                                                                                 |
+| `compensate`      | length      | `0.15pt` | Compensating overlap to add to avoid glitches.                                                                                             |
 | `gradient angle`  | angle       |  `135`   | Change the gradient angle.                                                                                                                 |
 | `gradient`        | boolean     |   true   | Toggle the color gradient                                                                                                                  |
 | `image`           | LaTeX       |          | Automatically center an image (you have to care for the size and maybe adjust the `version` and `level` to keep the qr-code readable).[^1] |

--- a/fancyqr-doc.tex
+++ b/fancyqr-doc.tex
@@ -68,6 +68,7 @@
 		\midrule
 		classic         & boolean &   false  & Use the classic qr-code style (black with flat rectangles, this loads the |flat| style).                                \\
 		color           & color   &          & Disables the |gradient| and sets the color accordingly.      \\
+		compensate      & length  & 0.15pt & Compensating overlap to add to avoid glitches.               \\
 		gradient        & boolean &   true   & Toggle the color gradient                                    \\
 		gradient angle  & angle   &  135     & Change the gradient angle.                                   \\
 		image           & \LaTeX   &          & Automatically center an image (you have to care for the size and maybe adjust the |version| and |level| to keep the qr-code readable).\footnote{The package will automatically calculate the required \ltx{\\FancyQrDoNotPrintSquare} (you have to make sure that the qr-code still has enough information to be readable). Therefore, the image will not scale with the qr-code.} \\

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -274,13 +274,14 @@
 \define@key{fancyqr}{random color}{\@fancyqr@randomcolor@true\def\@fancyqr@random@colors{#1}}
 \define@key{fancyqr}{width}{\setkeys{qr}{height=#1}}
 \define@key{fancyqr}{size}{\setkeys{qr}{height=#1}}
+\define@key{fancyqr}{compensate}{\setlength\fancyqr@edge@compensate{#1}}
 % \fancyqr@loaded@style
 \def\fancyqr@flat@style{flat}
 \define@boolkey{fancyqr}[@fancyqr@]{classic}[true]{} % if@fancyqr@classic
 \def\fancyqr@classic{%
 \ifx\fancyqr@loaded@style\fancyqr@flat@style\else\FancyQrLoad{\fancyqr@flat@style}\fi
 \setkeys{fancyqr}{%
-   gradient=false,color=black,l color=black,r color=black%
+   gradient=false,color=black,l color=black,r color=black,compensate=\z@\relax
 }%
 }
 


### PR DESCRIPTION
I added a new option which allows to manually tweak the overhang of each tile (which avoids graphic glitches due to the anti aliasing of certain pdf viewers). 
Additionally, the `classic` style now uses this option to set the overlap to `0pt` wrt. #38.

Is this what you wanted @jasperhabicht? 

Zooming in, `classic` now produces (the small lightgray line refers to the glitches, they are not visible in print):

![Screenshot_20241121_184544](https://github.com/user-attachments/assets/ef756589-4a3f-40e4-b572-7442180a2623)
