### PR TITLE
Rounded Cutoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You may use `\fancyqr` just like the normal `\qrcode` (`\fancyqr[<qr-options>]{<
 
 *fancyqr* is actively developed by *Florian Sihler* (contact me at: <florian.sihler@uni-ulm.de>) under the [GPLv3 License](LICENSE). I am very happy about every contribution (see [CONTRIBUTING.md](CONTRIBUTING.md)). You can find it on CTAN (<https://www.ctan.org/pkg/fancyqr>).
 
-If you do want to hide a center square (e.g., because you want to embed an image), you can use `\FancyQrDoNotPrintSquare{<x>}{<y>}` to hide a rectangle with radius x and y set from the center. If you choose this option, the default `\FancyQrRoundCut` that rounds cut corners can be changed with `\FancyQrHardCut`.
+If you do want to hide a center square (e.g., because you want to embed an image), you can use `\FancyQrDoNotPrintSquare{<x>}{<y>}` to hide a rectangle with radius x and y set from the center (with `\FancyQrDoNotPrintRadius{<factor>}` you can apply a [rounding](https://github.com/EagleoutIce/fancyqr/pull/41) to this!). If you choose this option, the default `\FancyQrRoundCut` that rounds cut corners can be changed with `\FancyQrHardCut`.
 At the moment, there are six other styles (`flat`, `frame`, `blobs`, `glitch`, and `dots`) that you can load (locally) by using `\FancyQrLoad{<name>}`. The default style is named `default` and can be 'reset' by `\FancyQrLoad{default}` or `\FancyQrLoadDefault`.
 
 There are the following extra qr-options (you can set all of them with `\fancyqrset{<keys>}`):

--- a/fancyqr-doc.tex
+++ b/fancyqr-doc.tex
@@ -44,7 +44,7 @@
 	\texttt{fancyqr} is a simple package to create fancy qr-codes with the help of the \textit{\href{https://www.ctan.org/pkg/qrcode}{qrcode}}-package.
 	You can use the |\fancyqr|-macro just like the normal |\qrcode|.\footnote{\ltx{\\fancyqr[<qr-options>]\{<url>\}}}
 
-	If you do want to hide a center square (e.g, because you want to embed an image) you can use |\FancyQrDoNotPrintSquare{<x>}{<y>}| to hide a rectangle with radius x and y set from the center. If you choose this option, the default |\FancyQrRoundCut| that rounds cut corners can be changed with |\FancyQrHardCut|.
+	If you do want to hide a center square (e.g, because you want to embed an image) you can use |\FancyQrDoNotPrintSquare{<x>}{<y>}| to hide a rectangle with radius x and y set from the center (with |\FancyQrDoNotPrintRadius{<factor>}| you can apply a \href{https://github.com/EagleoutIce/fancyqr/pull/41}{rounding} to this!). If you choose this option, the default |\FancyQrRoundCut| that rounds cut corners can be changed with |\FancyQrHardCut|.
 	At the moment, there are six other styles for the qr-code |flat|, |frame|, |blobs|, |glitch|, and |dots|, that you can load (locally) by using |\FancyQrLoad{<name>}|. The default style is named |default| and can be 'reset' by |\FancyQrLoad{default}| or |\FancyQrLoadDefault|.
 
 	All of the extra qr-options (you can set all of them with |\fancyqrset{<keys>}|) are showcased in \autoref{tbl:extra-keys}.

--- a/fancyqr.sty
+++ b/fancyqr.sty
@@ -121,12 +121,30 @@
    \else\qr@white@format\fi
 }%
 
-\def\FancyQrDoNotPrintSquare#1#2{\def\fancy@qr@donotprint@center@x{#1}\def\fancy@qr@donotprint@center@y{#2}}
+% #1 width
+% #2 height
+\def\FancyQrDoNotPrintSquare#1#2{%
+   \def\fancy@qr@donotprint@center@x{#1}%
+   \def\fancy@qr@donotprint@center@y{#2}%
+}
 \FancyQrDoNotPrintSquare00
+% is a factor between 0 and 1
+\def\FancyQrDoNotPrintRadius#1{%
+   \def\fancy@qr@donotprint@center@r{#1}%
+}
+\FancyQrDoNotPrintRadius0
 
 \newif\iffancy@qr@do@print@
 \def\qr@fancy@updateif#1#2{\fancy@qr@do@print@true
-\ifnum#1>\@do@y@min\relax \ifnum#1<\@do@y@max\relax \ifnum#2>\@do@x@min\relax \ifnum#2<\@do@x@max\relax \fancy@qr@do@print@false \fi\fi\fi\fi}
+\ifdim\fancy@qr@donotprint@center@r\p@>\z@
+   \ifnum#1>\@do@y@min\relax \ifnum#1<\@do@y@max\relax \ifnum#2>\@do@x@min\relax \ifnum#2<\@do@x@max\relax
+      \ifdim\fpeval{sqrt((#1-\@half@max@y)^2 + (#2-\@half@max@x)^2)}\p@<\@max@rcrad\p@
+         \fancy@qr@do@print@false
+      \fi
+   \fi\fi\fi\fi
+\else
+\ifnum#1>\@do@y@min\relax \ifnum#1<\@do@y@max\relax \ifnum#2>\@do@x@min\relax \ifnum#2<\@do@x@max\relax \fancy@qr@do@print@false \fi\fi\fi\fi\fi
+}
 
 \newif\iffancy@qr@roundcut@
 \fancy@qr@roundcut@true
@@ -147,8 +165,8 @@
 
 \newif\if@fancyqr@image@
 
+\def\qr@white{0}\def\qr@black{1}%
 \def\fancy@qr@printmatrix#1{%
-   \def\qr@white{0}\def\qr@black{1}%
    \protected@edef\fancyqr@currprint{#1}%
    \let\qr@black@fixed\qr@black \let\qr@white@fixed\qr@white
    \let\qr@black@format\qr@black \let\qr@white@format\qr@white
@@ -180,6 +198,7 @@
       \edef\@do@x@max{\the\numexpr\@half@max@x+\fancy@qr@donotprint@center@x+\@ne}%
       \edef\@do@y@min{\the\numexpr\@half@max@y-\fancy@qr@donotprint@center@y-\@ne}%
       \edef\@do@y@max{\the\numexpr\@half@max@y+\fancy@qr@donotprint@center@y+\@ne}%
+      \edef\@max@rcrad{\fpeval{max((\@ne-\fancy@qr@donotprint@center@r)*\fancy@qr@donotprint@center@x,(\@ne-\fancy@qr@donotprint@center@r)*\fancy@qr@donotprint@center@y)+\fancyqr@edge@compensate}}%
       \edef\@tmp@tight{\ifqr@tight\z@\else-4\fi}%
       \picture(\qr@minipagewidth,\qr@minipagewidth)(\the\numexpr\@ne+\@tmp@tight,\@tmp@tight)
       \qr@for \i=\@ne to \@max@y by \@ne{\qr@for \j=\@ne to \@max@x by \@ne{%

--- a/qr-minimal.tex
+++ b/qr-minimal.tex
@@ -1,12 +1,22 @@
 \documentclass{article}
 
+\errorcontextlines=99999
 \usepackage{fancyqr}
 
 \usepackage[active,tightpage]{preview}
-\setlength\PreviewBorder{0pt}
+\setlength\PreviewBorder{50pt}
+\usepackage{pgffor}
 
+\makeatletter
+% make all black:
+\def\qr@white{1}
 \begin{document}
 \preview
-\fancyqr[classic,padding]{https://github.com/EagleoutIce/fancyqr}
+\foreach \i in {0,.1,...,1}{%
+\expandafter\FancyQrDoNotPrintRadius\expandafter{\i}%
+\fancyqr[classic,image=\Large\color{green}@,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
+\fancyqr[classic,image=\Large\color{purple}*\fpeval{round(\i,2)}*,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
+}\\
+\centerline{Various Variants of \texttt{\textbackslash FancyQrDoNotPrintRadius}}
 \endpreview
 \end{document}

--- a/qr-minimal.tex
+++ b/qr-minimal.tex
@@ -1,22 +1,12 @@
 \documentclass{article}
 
-\errorcontextlines=99999
 \usepackage{fancyqr}
 
 \usepackage[active,tightpage]{preview}
-\setlength\PreviewBorder{50pt}
-\usepackage{pgffor}
+\setlength\PreviewBorder{0pt}
 
-\makeatletter
-% make all black:
-\def\qr@white{1}
 \begin{document}
 \preview
-\foreach \i in {0,.1,...,1}{%
-\expandafter\FancyQrDoNotPrintRadius\expandafter{\i}%
-\fancyqr[classic,image=\Large\color{green}@,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
-\fancyqr[classic,image=\Large\color{purple}*\fpeval{round(\i,2)}*,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
-}\\
-\centerline{Various Variants of \texttt{\textbackslash FancyQrDoNotPrintRadius}}
+\fancyqr[classic,padding]{https://github.com/EagleoutIce/fancyqr}
 \endpreview
 \end{document}


### PR DESCRIPTION
Currently, we do circle radius calculation but this is to be improved to really reflect the outer edge rounding:
![qr-minimal](https://github.com/user-attachments/assets/7f32ed1e-cb18-4a2d-8dde-4accce5a95af)

<details>
<summary>Code</summary>

```tex
\documentclass{article}

\errorcontextlines=99999
\usepackage{fancyqr}

\usepackage[active,tightpage]{preview}
\setlength\PreviewBorder{50pt}
\usepackage{pgffor}

\makeatletter
% make all black:
\def\qr@white{1}
\begin{document}
\preview
\foreach \i in {0,.1,...,1}{%
\expandafter\FancyQrDoNotPrintRadius\expandafter{\i}%
\fancyqr[classic,image=\Large\color{green}@,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
\fancyqr[classic,image=\Large\color{purple}*\fpeval{round(\i,2)}*,level=H,version=10]{https://github.com/EagleoutIce/fancyqr}\hfill
}\\
\centerline{Various Variants of \texttt{\textbackslash FancyQrDoNotPrintRadius}}
\endpreview
\end{document}
```

</details>